### PR TITLE
Update node to v16 and other small updates/improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v10
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           runs: 3
           urls: |
-            https://developer.chrome.com/docs/lighthouse/overview/
+            https://www.google.com
       - name: Lighthouse Report
         uses: ./ # Uses an action in the root directory
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
             https://web.dev/measure/
       - name: Lighthouse Report
         uses: ./ # Uses an action in the root directory
+        if: always()
         with:
           reports: '.lighthouseci'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,8 @@ jobs:
         with:
           runs: 3
           urls: |
-            https://www.google.com
+            https://web.dev
+            https://web.dev/measure/
       - name: Lighthouse Report
         uses: ./ # Uses an action in the root directory
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,7 @@ jobs:
         with:
           runs: 3
           urls: |
-            https://github.com/
-            https://duckduckgo.com/
+            https://developer.chrome.com/docs/lighthouse/overview/
       - name: Lighthouse Report
         uses: ./ # Uses an action in the root directory
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@v2
+        uses: treosh/lighthouse-ci-action@v10
         with:
           runs: 3
           urls: |

--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: 'Github Token'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Updated based on https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/